### PR TITLE
Add hook for package stage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ class ServerlessParameters {
   }
 
   addParameters() {
-    this.serverless.cli.consoleLog('');
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
     // this.serverless.cli.consoleLog(template);
 
@@ -23,7 +22,7 @@ class ServerlessParameters {
     }
 
     template.Parameters = parameters
-    this.serverless.cli.consoleLog('Added parameters to template');
+    this.serverless.cli.log('Added parameters to template');
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ class ServerlessParameters {
     this.serverless = serverless;
     this.options = options;
     this.hooks = {
+      'before:package:createDeploymentArtifacts': this.addParameters.bind(this),
       'before:deploy:deploy': this.addParameters.bind(this),
     };
   }


### PR DESCRIPTION
You can use `sls package` to create more portable deploys by leaving site specific values as parameters.